### PR TITLE
fix: manual node selection no longer resets auto_select mode

### DIFF
--- a/src-tauri/src/smart_switch.rs
+++ b/src-tauri/src/smart_switch.rs
@@ -928,6 +928,18 @@ async fn tick(state: &AppState) -> Result<(), String> {
             .unwrap_or_else(|| best_id.clone())
     };
 
+    // Re-check auto_select before applying: mode may have changed during
+    // network probing. If no longer smart, return silently instead of
+    // logging an error from select_current_node_serialized.
+    let still_smart = state
+        .with_store(|s| Ok(s.settings.auto_select.is_smart()))
+        .unwrap_or(false);
+    if !still_smart {
+        app_log::debug("smart_switch", "tick cancelled: auto_select no longer smart");
+        ctrl().set_phase(Phase::Ok);
+        return Ok(());
+    }
+
     apply_switch(state, &best_id, hard_fail)?;
 
     {

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -37,14 +37,14 @@ struct TrafficViewCache {
 fn apply_selected_node(
     settings: &mut crate::domain::AppSettings,
     node_id: String,
-    manual: bool,
+    _manual: bool,
 ) -> bool {
     let was_kernel = settings.auto_select.is_kernel();
     settings.current_node_id = Some(node_id);
-    if manual {
-        settings.auto_select = crate::domain::AutoSelectMode::Off;
-        settings.smart_switch = false;
-    }
+    // Manual node selection no longer resets auto_select mode.
+    // Mode (smart/auto/manual) and node selection are independent:
+    // manually picking a node is a temporary override of the current node,
+    // not a switch to permanent manual mode.
     was_kernel
 }
 
@@ -167,7 +167,11 @@ mod kernel_selection_poll_tests {
             .expect("kernel-mode manual select must not touch the urltest group");
         assert!(!selected_live);
         assert!(was_kernel);
-        assert_eq!(settings.auto_select, crate::domain::AutoSelectMode::Off);
+        assert_eq!(
+            settings.auto_select,
+            crate::domain::AutoSelectMode::Kernel,
+            "manual select should not change auto_select mode"
+        );
         assert_eq!(settings.current_node_id.as_deref(), Some("node-a"));
 
         let _ = std::fs::remove_dir_all(test_dir);


### PR DESCRIPTION
## 问题

在智能切换或内核自动模式下，手动点击一个节点会导致 `auto_select` 被重置为 `Off`，悄悄地把模式切回手动。用户以为还在智能模式，但实际上智能切换已经失效了。

```
[error] [smart_switch] select_node_live failed for ...: core error: 智能切换已关闭
```

## 修改

### `state.rs` — `apply_selected_node`
手动选择节点不再修改 `auto_select` 模式。模式和节点选择解耦：
- 手动点节点 = 临时覆盖当前节点
- 模式（智能/自动/手动）保持不变
- 下一轮智能切换 tick 正常执行

### `smart_switch.rs` — `tick()`
在 `apply_switch` 前加 `is_smart()` 二次检查，防止竞态条件下（网络探测期间模式被其他路径修改）误报错误日志。

## 测试

已在本地编译并运行，智能模式下手动切节点后模式保持智能，下一轮 tick 正常切换。